### PR TITLE
Run rustfmt on every Rust file

### DIFF
--- a/examples/bar.rs
+++ b/examples/bar.rs
@@ -3,20 +3,9 @@ extern crate xcbars;
 extern crate futures;
 extern crate tokio_core;
 
-use xcbars::{
-    BarBuilder,
-    Geometry,
-    Color,
-    Slot,
-    Component,
-    Error,
-    Position,
-};
+use xcbars::{BarBuilder, Geometry, Color, Slot, Component, Error, Position};
 
-use xcbars::components::{
-    Pipe,
-    NetworkUsage,
-};
+use xcbars::components::{Pipe, NetworkUsage};
 
 use futures::{Sink, Stream, Future};
 use tokio_core::reactor::Handle;
@@ -31,11 +20,9 @@ struct Counter {
 
 impl Component for Counter {
     type Error = Error;
-    type Stream = Box<Stream<Item=String, Error=Error>>;
+    type Stream = Box<Stream<Item = String, Error = Error>>;
 
-    fn stream(self, handle: Handle)
-        -> Box<Stream<Item=String, Error=Error>>
-    {
+    fn stream(self, handle: Handle) -> Box<Stream<Item = String, Error = Error>> {
         let (tx, rx) = channel(1);
 
         let remote = handle.remote().clone();
@@ -46,8 +33,8 @@ impl Component for Counter {
                 let tx = tx.clone();
                 remote.clone().spawn(move |_| {
                     tx.send(format!("Count: {}", current))
-                         .map(|_| ())
-                         .map_err(|_| ())
+                        .map(|_| ())
+                        .map_err(|_| ())
                 });
                 current += self.step;
                 sleep(Duration::from_secs(1));
@@ -61,7 +48,7 @@ impl Component for Counter {
 fn main() {
     let down_speed = NetworkUsage {
         interface: "wlp58s0".to_string(),
-        .. Default::default()
+        ..Default::default()
     };
 
     BarBuilder::new()
@@ -74,13 +61,15 @@ fn main() {
         .background(Color::new(1.0, 0.5, 0.5))
         .foreground(Color::new(1., 1., 1.))
         .font("Inconsolata 14")
-        .add_component(Slot::Left, Counter {
-            start: 123,
-            step: 2,
-        })
-        .add_component(Slot::Center, Pipe {
-            command: "date",
-        })
+        .add_component(
+            Slot::Left,
+            Counter {
+                start: 123,
+                step: 2,
+            },
+        )
+        .add_component(Slot::Center, Pipe { command: "date" })
         .add_component(Slot::Right, composite!("Down: ", down_speed))
-        .run().unwrap();
+        .run()
+        .unwrap();
 }

--- a/src/bar.rs
+++ b/src/bar.rs
@@ -1,13 +1,7 @@
 use item_state::ItemState;
-use bar_builder::{
-    UpdateStream,
-};
+use bar_builder::UpdateStream;
 use std::rc::Rc;
-use xcb::{
-    Connection,
-    Rectangle,
-    Window,
-};
+use xcb::{Connection, Rectangle, Window};
 use futures::stream::{Merge, MergedItem};
 use futures::{Future, Stream};
 use xcb_event_stream::XcbEventStream;
@@ -39,7 +33,7 @@ impl Bar {
     }
 
     /// Launch and run the bar.
-    pub fn run(mut self) -> Box<Future<Item=(), Error=()>> {
+    pub fn run(mut self) -> Box<Future<Item = (), Error = ()>> {
         let future = self.get_stream()
             .map_err(|e| ::error::Error::with_chain(e, ErrorKind::ItemError))
             .for_each(move |item| -> Result<()> {
@@ -92,11 +86,12 @@ impl Bar {
     /// Unforunately centering means that all components
     /// must be redrawn if even one of them changes size.
     fn redraw_center(&mut self) -> Result<()> {
-        let width_all: u16 = self.center_items.iter()
+        let width_all: u16 = self.center_items
+            .iter()
             .map(|item| item.get_content_width())
             .sum();
 
-        let mut pos = (self.geometry.width())/2-width_all/2;
+        let mut pos = (self.geometry.width()) / 2 - width_all / 2;
 
         for item in self.center_items.iter() {
             self.item_positions[item.get_id()].0 = pos;
@@ -114,19 +109,19 @@ impl Bar {
         let mut pos = self.geometry.width();
 
         for n in 0..self.right_items.len() {
-            let item = &self.right_items[self.right_items.len()-n-1];
+            let item = &self.right_items[self.right_items.len() - n - 1];
 
             pos -= item.get_content_width();
 
-            if n < self.right_items.len()-index-1 {
+            if n < self.right_items.len() - index - 1 {
                 continue;
             }
 
             if size_changed {
                 let mut bg_start = pos;
                 let mut bg_end = pos + item.get_content_width();
-                
-                if n == self.right_items.len()-1 {
+
+                if n == self.right_items.len() - 1 {
                     let old_start = self.item_positions[item.get_id()].0 as u16;
                     if old_start < bg_start {
                         bg_start = old_start;
@@ -171,8 +166,8 @@ impl Bar {
             if size_changed {
                 let mut bg_start = pos;
                 let mut bg_end = pos + item.get_content_width();
-                
-                if n == self.left_items.len()-1 {
+
+                if n == self.left_items.len() - 1 {
                     let old_end = self.item_positions[item.get_id()].0 +
                         self.item_positions[item.get_id()].1;
                     if bg_end < old_end {
@@ -201,26 +196,34 @@ impl Bar {
             return Ok(());
         }
 
-        try_xcb!(xcb::copy_area_checked, "failed to copy pixmap",
+        try_xcb!(
+            xcb::copy_area_checked,
+            "failed to copy pixmap",
             &self.conn,
             item.get_pixmap(),
             self.window,
             self.foreground,
-            0, 0,
-            pos as i16, 0,
+            0,
+            0,
+            pos as i16,
+            0,
             item.get_content_width() as u16,
-            self.geometry.height());
+            self.geometry.height()
+        );
 
         Ok(())
     }
 
     /// Draws the background starting at point a on the x-axis until point b.
     fn paint_bg(&self, a: u16, b: u16) -> Result<()> {
-        try_xcb!(xcb::poly_fill_rectangle, "failed to draw background",
+        try_xcb!(
+            xcb::poly_fill_rectangle,
+            "failed to draw background",
             &self.conn,
             self.window,
             self.foreground,
-            &[Rectangle::new(a as i16, 0, b-a, self.geometry.height())]);
+            &[Rectangle::new(a as i16, 0, b - a, self.geometry.height())]
+        );
 
         Ok(())
     }

--- a/src/component.rs
+++ b/src/component.rs
@@ -4,37 +4,40 @@ use std::result::Result as StdResult;
 use tokio_core::reactor::Handle;
 
 pub trait Component {
-    type Stream: Stream<Item=String, Error=Self::Error> + 'static;
+    type Stream: Stream<Item = String, Error = Self::Error> + 'static;
     type Error: ::std::error::Error + Send + 'static;
 
-    fn init(&mut self) -> StdResult<(), Self::Error> { Ok(()) }
+    fn init(&mut self) -> StdResult<(), Self::Error> {
+        Ok(())
+    }
     fn stream(self, handle: Handle) -> Self::Stream;
 }
 
 pub trait ComponentCreator {
     fn init(&mut self) -> StdResult<(), Error>;
-    fn into_stream(self: Box<Self>, handle: Handle) -> Box<Stream<Item=String, Error=Error>>;
-    fn create(mut self: Box<Self>, handle: Handle)
-        -> StdResult<Box<Stream<Item=String, Error=Error>>, Error>
-    {
+    fn into_stream(self: Box<Self>, handle: Handle) -> Box<Stream<Item = String, Error = Error>>;
+    fn create(
+        mut self: Box<Self>,
+        handle: Handle,
+    ) -> StdResult<Box<Stream<Item = String, Error = Error>>, Error> {
         self.init()?;
         Ok(self.into_stream(handle))
     }
 }
 
 impl<C> ComponentCreator for C
-    where C: Component,
+where
+    C: Component,
 {
     fn init(&mut self) -> StdResult<(), Error> {
-        Component::init(self)
-            .chain_err(|| "Failed to initialize component")
+        Component::init(self).chain_err(|| "Failed to initialize component")
     }
 
-    fn into_stream(self: Box<Self>, handle: Handle)
-        -> Box<Stream<Item=String, Error=Error>>
-    {
-        Box::new(self.stream(handle)
-           .map_err(|e| Error::with_chain(e, "Component raised an error")))
+    fn into_stream(self: Box<Self>, handle: Handle) -> Box<Stream<Item = String, Error = Error>> {
+        Box::new(
+            self.stream(handle)
+                .map_err(|e| Error::with_chain(e, "Component raised an error")),
+        )
     }
 }
 

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -5,4 +5,3 @@ pub mod text;
 pub use self::pipe::Pipe;
 pub use self::network_usage::NetworkUsage;
 pub use self::text::Text;
-

--- a/src/components/network_usage.rs
+++ b/src/components/network_usage.rs
@@ -1,7 +1,4 @@
-use futures::{
-    Future,
-    Stream,
-};
+use futures::{Future, Stream};
 use std::sync::Arc;
 use tokio_timer::Timer;
 use tokio_core::reactor::Handle;
@@ -43,12 +40,12 @@ pub struct NetworkUsage {
 impl Default for NetworkUsage {
     fn default() -> NetworkUsage {
         NetworkUsage {
-            interface:         "eth0".to_string(),
-            direction:         Direction::Incoming,
-            scale:             Scale::Binary,
-            percision:         3,
+            interface: "eth0".to_string(),
+            direction: Direction::Incoming,
+            scale: Scale::Binary,
+            percision: 3,
             refresh_frequency: Duration::from_secs(10),
-            sample_duration:   Duration::from_secs(1),
+            sample_duration: Duration::from_secs(1),
         }
     }
 }
@@ -60,11 +57,11 @@ fn get_prefix(scale: Scale, power: u8) -> &'static str {
         (Scale::Decimal, 2) => "Mb/s",
         (Scale::Decimal, 3) => "Gb/s",
         (Scale::Decimal, 4) => "Tb/s",
-        (Scale::Binary,  0) => "B/s",
-        (Scale::Binary,  1) => "KiB/s",
-        (Scale::Binary,  2) => "MiB/s",
-        (Scale::Binary,  3) => "GiB/s",
-        (Scale::Binary,  4) => "TiB/s",
+        (Scale::Binary, 0) => "B/s",
+        (Scale::Binary, 1) => "KiB/s",
+        (Scale::Binary, 2) => "MiB/s",
+        (Scale::Binary, 3) => "GiB/s",
+        (Scale::Binary, 4) => "TiB/s",
         _ => "X/s",
     }
 }
@@ -72,7 +69,7 @@ fn get_prefix(scale: Scale, power: u8) -> &'static str {
 fn get_number_scale(number: u64, scale: Scale) -> (f64, u8) {
     let log = (number as f64).log(scale.base() as f64);
     let wholes = log.floor();
-    let over = (scale.base() as f64).powf(log-wholes);
+    let over = (scale.base() as f64).powf(log - wholes);
     (over, wholes as u8)
 }
 
@@ -94,7 +91,7 @@ fn get_bytes(interface: &str, dir: Direction) -> ::std::io::Result<Option<u64>> 
 
 impl Component for NetworkUsage {
     type Error = Error;
-    type Stream = Box<Stream<Item=String, Error=Error>>;
+    type Stream = Box<Stream<Item = String, Error = Error>>;
 
     fn init(&mut self) -> Result<()> {
         ::procinfo::net::dev::dev()?
@@ -118,10 +115,11 @@ impl Component for NetworkUsage {
 
                     let first = get_bytes(conf.interface.as_str(), conf.direction)
                         .unwrap().unwrap();
-                    
+
                     timer.sleep(conf.sample_duration)
                         .and_then(move |()| {
-                            let second = get_bytes(conf.interface.as_str(), conf.direction).unwrap().unwrap();
+                            let second = get_bytes(conf.interface.as_str(), conf.direction)
+                                .unwrap().unwrap();
                             let per_second = (second-first)/conf.sample_duration.as_secs();
                             Ok(per_second)
                         })
@@ -132,6 +130,7 @@ impl Component for NetworkUsage {
                             format!("{} {}", num, get_prefix(conf2.scale, power))
                         })
                 })
-        }).map_err(|_| "timer error".into()).boxed()
+        }).map_err(|_| "timer error".into())
+            .boxed()
     }
 }

--- a/src/components/pipe.rs
+++ b/src/components/pipe.rs
@@ -1,9 +1,6 @@
 use component::Component;
 use tokio_core::reactor::Handle;
-use std::io::{
-    BufReader,
-    BufRead,
-};
+use std::io::{BufReader, BufRead};
 use std::process::{Stdio, Command};
 use tokio_process::{ChildStdout, CommandExt};
 use tokio_io::io::Lines;
@@ -30,13 +27,10 @@ impl Default for Pipe {
 }
 
 impl Pipe {
-    fn reader(&self, handle: &Handle)
-              -> BufReader<ChildStdout>
-    {
+    fn reader(&self, handle: &Handle) -> BufReader<ChildStdout> {
         let mut cmd = Command::new(self.command.as_str());
         cmd.args(self.args.as_slice());
-        cmd.stdin(Stdio::inherit())
-            .stdout(Stdio::piped());
+        cmd.stdin(Stdio::inherit()).stdout(Stdio::piped());
         let mut child = cmd.spawn_async(&handle).unwrap();
         let stdout = child.stdout().take().unwrap();
         handle.spawn(child.map(|_| ()).map_err(|_| ()));
@@ -46,25 +40,30 @@ impl Pipe {
 
 impl Component for Pipe {
     type Error = Error;
-    type Stream = Box<Stream<Item=String, Error=Error>>;
-    
+    type Stream = Box<Stream<Item = String, Error = Error>>;
+
     fn stream(self, handle: Handle) -> Self::Stream {
         if let Some(refresh_rate) = self.refresh_rate {
-            Box::new(LoopFn::new(move || {
-                let timer = Timer::default();
-                Ok::<_, Error>(::tokio_io::io::lines(self.reader(&handle))
-                               .map(|s| Some(s))
-                               .chain(timer.sleep(refresh_rate)
-                                      .into_stream()
-                                      .map(|_| None)
-                                      .from_err())
-                               .map_err(|e| Error::from(e)))
-            })
-                     .flatten()
-                     .filter_map(|s| s))
+            Box::new(
+                LoopFn::new(move || {
+                    let timer = Timer::default();
+                    Ok::<_, Error>(
+                        ::tokio_io::io::lines(self.reader(&handle))
+                            .map(|s| Some(s))
+                            .chain(
+                                timer
+                                    .sleep(refresh_rate)
+                                    .into_stream()
+                                    .map(|_| None)
+                                    .from_err(),
+                            )
+                            .map_err(|e| Error::from(e)),
+                    )
+                }).flatten()
+                    .filter_map(|s| s),
+            )
         } else {
-            Box::new(::tokio_io::io::lines(self.reader(&handle))
-                     .from_err())
+            Box::new(::tokio_io::io::lines(self.reader(&handle)).from_err())
         }
     }
 }

--- a/src/utils/composite.rs
+++ b/src/utils/composite.rs
@@ -44,9 +44,13 @@ macro_rules! composite {
                 fn stream(self, handle: Handle) -> Self::Stream {
                     CompositeComponentStream {
                         states: vec![String::new(); self.components.len()],
-                        streams: self.components.into_iter().enumerate()
-                            .map(|(id, c)| Box::new(c.0.into_stream(handle.clone())
-                                 .map(move |s| (id, s))) as Box<Stream<Item=(usize, String), Error=Error>>)
+                        streams: self.components
+                            .into_iter()
+                            .enumerate()
+                            .map(|(id, c)| {
+                                Box::new(c.0.into_stream(handle.clone()).map(move |s| (id, s))) as
+                                    Box<Stream<Item = (usize, String), Error = Error>>
+                            })
                             .collect(),
                     }
                 }
@@ -60,12 +64,12 @@ macro_rules! composite {
             impl Stream for CompositeComponentStream {
                 type Item = String;
                 type Error = Error;
-                
+
                 fn poll(&mut self) -> Poll<Option<String>, Error> {
                     let mut do_update = false;
                     for stream in self.streams.iter_mut() {
                         match stream.poll() {
-                            Ok(Async::Ready(Some((id, update)))) => {       
+                            Ok(Async::Ready(Some((id, update)))) => {
                                 do_update = true;
                                 self.states[id] = update;
                             },

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -11,4 +11,3 @@ macro_rules! try_xcb {
             .map_err(|e| $crate::error::Error::with_chain($crate::error::Error::from(e), $error))?;
     }
 }
-

--- a/src/utils/stream_loop_fn.rs
+++ b/src/utils/stream_loop_fn.rs
@@ -1,15 +1,16 @@
 use futures::{Stream, Future, IntoFuture, Poll, Async};
 
-pub struct LoopFn<C,F> {
+pub struct LoopFn<C, F> {
     creator: C,
     current: Option<F>,
 }
 
-impl<C,F> LoopFn<C,F> {
-    pub fn new<I>(creator: C) -> LoopFn<C,F>
-        where C: Fn() -> I,
-              I: IntoFuture<Future=F,Item=F::Item,Error=F::Error>,
-              F: Future,
+impl<C, F> LoopFn<C, F> {
+    pub fn new<I>(creator: C) -> LoopFn<C, F>
+    where
+        C: Fn() -> I,
+        I: IntoFuture<Future = F, Item = F::Item, Error = F::Error>,
+        F: Future,
     {
         LoopFn {
             creator,
@@ -18,10 +19,11 @@ impl<C,F> LoopFn<C,F> {
     }
 }
 
-impl<C,F,I> Stream for LoopFn<C,F>
-    where C: Fn() -> I,
-          I: IntoFuture<Future=F,Item=F::Item,Error=F::Error>,
-          F: Future,
+impl<C, F, I> Stream for LoopFn<C, F>
+where
+    C: Fn() -> I,
+    I: IntoFuture<Future = F, Item = F::Item, Error = F::Error>,
+    F: Future,
 {
     type Item = F::Item;
     type Error = F::Error;
@@ -42,7 +44,7 @@ impl<C,F,I> Stream for LoopFn<C,F>
             Ok(Async::Ready(t)) => {
                 self.current = Some((self.creator)().into_future());
                 Ok(Async::Ready(Some(t)))
-            },
+            }
             Ok(Async::NotReady) => Ok(Async::NotReady),
             Err(e) => Err(e),
         }

--- a/src/xcb_event_stream.rs
+++ b/src/xcb_event_stream.rs
@@ -8,9 +8,7 @@ pub struct XcbEventStream {
 
 impl XcbEventStream {
     pub fn new(conn: Connection) -> XcbEventStream {
-        XcbEventStream {
-            conn,
-        }
+        XcbEventStream { conn }
     }
 }
 


### PR DESCRIPTION
See dogamak/xcbars#11.

Every file has been automatically formatted by rustfmt to make sure that
code style is consistent. A few manual interventions have been made in
code that exceeded maximum line length but couldn't be formatted by
rustfmt due to macros.

I have tested the functionality of this commit by simply running the example (with the orphan issue commented out). So basic functionality still works. 