### PR TITLE
Fix `composite!` macro

### DIFF
--- a/examples/bar.rs
+++ b/examples/bar.rs
@@ -68,7 +68,14 @@ fn main() {
                 step: 2,
             },
         )
-        .add_component(Slot::Center, Pipe { command: "date" })
+        .add_component(
+            Slot::Center,
+            Pipe {
+                command: "date".into(),
+                args: Vec::new(),
+                refresh_rate: Some(Duration::from_secs(1)),
+            },
+        )
         .add_component(Slot::Right, composite!("Down: ", down_speed))
         .run()
         .unwrap();

--- a/src/component.rs
+++ b/src/component.rs
@@ -2,6 +2,7 @@ use futures::Stream;
 use error::*;
 use std::result::Result as StdResult;
 use tokio_core::reactor::Handle;
+use components::Text;
 
 pub trait Component {
     type Stream: Stream<Item = String, Error = Self::Error> + 'static;
@@ -38,6 +39,23 @@ where
             self.stream(handle)
                 .map_err(|e| Error::with_chain(e, "Component raised an error")),
         )
+    }
+}
+
+pub struct SubComponent(pub Box<ComponentCreator>);
+
+impl<'s> From<&'s str> for SubComponent {
+    fn from(s: &'s str) -> SubComponent {
+        SubComponent(Box::new(Text { text: s.to_string() }))
+    }
+}
+
+impl<C> From<C> for SubComponent
+where
+    C: ComponentCreator + 'static,
+{
+    fn from(c: C) -> SubComponent {
+        SubComponent(Box::new(c))
     }
 }
 

--- a/src/utils/composite.rs
+++ b/src/utils/composite.rs
@@ -2,28 +2,9 @@
 macro_rules! composite {
     ( $( $arg:expr ),+ ) => {
         {
-            use $crate::components::Text;
-            use $crate::component::{Component, ComponentCreator};
+            use $crate::component::{Component, SubComponent};
             use $crate::Error;
             use ::futures::{Poll, Async};
-
-            struct SubComponent(Box<ComponentCreator>);
-
-            impl<'s> From<&'s str> for SubComponent {
-                fn from(s: &'s str) -> SubComponent {
-                    SubComponent(Box::new(Text {
-                        text: s.to_string(),
-                    }))
-                }
-            }
-
-            impl<C> From<C> for SubComponent
-                where C: ComponentCreator + 'static,
-            {
-                fn from(c: C) -> SubComponent {
-                    SubComponent(Box::new(c))
-                }
-            }
 
             struct CompositeComponent {
                 components: Vec<SubComponent>,


### PR DESCRIPTION
See dogamak/xcbars#1.

Move `SubComponent` out of macro to fix trait issues. This now makes it
possible to run the examples again. Some small changes had to be made to the example too, because it was missing some fields.