### PR TITLE
Use primary output by default

### DIFF
--- a/examples/bar.rs
+++ b/examples/bar.rs
@@ -51,7 +51,7 @@ fn main() {
         ..Default::default()
     };
 
-    BarBuilder::new("DVI-0")
+    BarBuilder::new()
         .geometry(Geometry::Relative {
             position: Position::Top,
             height: 20,


### PR DESCRIPTION
This adds the output option to the builder and uses the primary output
when nothing else is specified.

This is the way you set the output now:
```
BarBuilder::new().output("DVI-0");
```

Solves #26.