### PR TITLE
Add ability to configure inner padding

### DIFF
--- a/src/bar.rs
+++ b/src/bar.rs
@@ -23,6 +23,7 @@ pub struct Bar {
     pub right_items: Vec<ItemState>,
     pub stream: Option<UpdateAndEventStream>,
     pub window: Window,
+    pub inner_padding: u16,
 }
 
 impl Bar {
@@ -106,7 +107,7 @@ impl Bar {
     /// Pretty much the same as `self.redraw_left` but with `left` replaced with `right`.
     /// The order in which the items are gone through is reversed.
     fn redraw_right(&mut self, size_changed: bool, index: usize) -> Result<()> {
-        let mut pos = self.geometry.width();
+        let mut pos = self.geometry.width() - self.inner_padding;
 
         for n in 0..self.right_items.len() {
             let item = &self.right_items[self.right_items.len() - n - 1];
@@ -154,7 +155,7 @@ impl Bar {
     /// redraw every component on the right of it. If the item has shrunk
     /// we must also repaint the exposed background.
     fn redraw_left(&mut self, size_changed: bool, index: usize) -> Result<()> {
-        let mut pos = 0;
+        let mut pos = self.inner_padding;
 
         for n in 0..self.left_items.len() {
             let item = &self.left_items[n];

--- a/src/bar_builder.rs
+++ b/src/bar_builder.rs
@@ -79,6 +79,7 @@ pub struct BarBuilder<'a> {
     fg_color: Color,
     font_name: String,
     items: Vec<(Slot, Box<ComponentCreator>)>,
+    inner_padding: u16,
 }
 
 impl<'a> BarBuilder<'a> {
@@ -92,6 +93,7 @@ impl<'a> BarBuilder<'a> {
             fg_color: Color::new(0., 0., 0.),
             items: vec![],
             font_name: String::new(),
+            inner_padding: 0,
         }
     }
 
@@ -121,6 +123,12 @@ impl<'a> BarBuilder<'a> {
     /// Set the bar's position and size.
     pub fn geometry(mut self, geometry: Geometry) -> Self {
         self.geometry = geometry;
+        self
+    }
+
+    /// Set the inner padding at the left and right side of the bar.
+    pub fn inner_padding(mut self, inner_padding: u16) -> Self {
+        self.inner_padding = inner_padding;
         self
     }
 
@@ -214,6 +222,9 @@ impl<'a> BarBuilder<'a> {
         let mut right_items = vec![];
         let mut updates: Option<UpdateStream> = None;
 
+        // Store inner padding before consumption
+        let inner_padding = self.inner_padding;
+
         // Consumes self
         let (items, properties) = self.into_items_and_props(&geometry);
         let properties = Rc::new(properties);
@@ -269,6 +280,7 @@ impl<'a> BarBuilder<'a> {
             right_items,
             stream: Some(stream),
             window,
+            inner_padding,
         })
     }
 }


### PR DESCRIPTION
This is quite the straight-forward fix. The configuration is done
through the builder and passed to the bar. The offsets are then just
applied in the left and right render method.

Resolves #14.