### PR TITLE
Fix center element redraw

### DIFF
--- a/src/bar.rs
+++ b/src/bar.rs
@@ -87,20 +87,24 @@ impl Bar {
     /// Unforunately centering means that all components
     /// must be redrawn if even one of them changes size.
     fn redraw_center(&mut self) -> Result<()> {
-        // Draw blank background to prevent leftovers after shrinkage
-        if let Some(first) = self.center_items.first() {
-            let old_start = self.item_positions[first.get_id()].0;
-            let old_width_all: u16 = self.center_items
-                .iter()
-                .map(|item| self.item_positions[item.get_id()].1)
-                .sum();
-            self.paint_bg(old_start, old_start + old_width_all)?;
-        }
-
+        // Get future width of all center components
         let width_all: u16 = self.center_items
             .iter()
             .map(|item| item.get_content_width())
             .sum();
+
+        // Draw blank background to prevent leftovers after shrinkage
+        // Only does this when component width has shrunk
+        let old_width_all: u16 = self.center_items
+            .iter()
+            .map(|item| self.item_positions[item.get_id()].1)
+            .sum();
+        if width_all < old_width_all {
+            if let Some(first) = self.center_items.first() {
+                let old_start = self.item_positions[first.get_id()].0;
+                self.paint_bg(old_start, old_start + old_width_all)?;
+            }
+        }
 
         let mut pos = (self.geometry.width()) / 2 - width_all / 2;
 

--- a/src/bar.rs
+++ b/src/bar.rs
@@ -87,6 +87,16 @@ impl Bar {
     /// Unforunately centering means that all components
     /// must be redrawn if even one of them changes size.
     fn redraw_center(&mut self) -> Result<()> {
+        // Draw blank background to prevent leftovers after shrinkage
+        if let Some(first) = self.center_items.first() {
+            let old_start = self.item_positions[first.get_id()].0;
+            let old_width_all: u16 = self.center_items
+                .iter()
+                .map(|item| self.item_positions[item.get_id()].1)
+                .sum();
+            self.paint_bg(old_start, old_start + old_width_all)?;
+        }
+
         let width_all: u16 = self.center_items
             .iter()
             .map(|item| item.get_content_width())


### PR DESCRIPTION
Whenever the center element shrinks it doesn't completely clear out the
previous elements, but leaves them and just draws the new elements. This
results in buggy leftovers.

To fix this before drawing new elements in the center the complete
background of the previous components is reset.

An alternative way of doing is would be redrawing the beginning of the last center block to the beginning of the new one and the end of the new one to the end of the old one, whenever the old one is bigger than the new one. I'm not quite certain which one is more efficient, so I decided to go for the simpler solution.

Resolves #30.