### PR TITLE
Reimplement `XcbEventStream` using `mio`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ repository = "dogamak/xcbars"
 
 [dependencies]
 cairo-rs = { git = "https://github.com/gtk-rs/cairo.git", features = ["xcb", "png"] }
+mio = "*"
 cairo-sys-rs = { git = "https://github.com/gtk-rs/cairo.git", features = ["xcb"] }
 error-chain = "*"
 futures = "*"

--- a/src/bar_builder.rs
+++ b/src/bar_builder.rs
@@ -268,7 +268,7 @@ impl<'a> BarBuilder<'a> {
         // a stream carrying events from XCB.
         let stream = updates
             .unwrap_or_else(|| Box::new(::futures::stream::empty()))
-            .merge(XcbEventStream::new(window_conn));
+            .merge(XcbEventStream::new(window_conn, &handle)?);
 
         Ok(Bar {
             center_items,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 extern crate xcb;
+extern crate mio;
 extern crate pango;
 extern crate cairo;
 extern crate cairo_sys;

--- a/src/xcb_event_stream.rs
+++ b/src/xcb_event_stream.rs
@@ -1,15 +1,48 @@
-use xcb::{Connection, GenericEvent};
+use xcb::{self, Connection, GenericEvent};
+use tokio_core::reactor::{PollEvented, Handle};
+use std::os::unix::io::{AsRawFd, RawFd};
 use futures::{Async, Poll, Stream};
-use error::Error;
+use error::{Result, Error};
+use mio;
+use std::io;
+
+struct InnerStream(Connection);
+
+impl AsRawFd for InnerStream {
+    fn as_raw_fd(&self) -> RawFd {
+        unsafe {
+            xcb::ffi::xcb_get_file_descriptor(self.0.get_raw_conn())
+        }
+    }
+}
+
+impl mio::Evented for InnerStream {
+    fn register(&self, poll: &mio::Poll, token: mio::Token,
+                interest: mio::Ready, opts: mio::PollOpt) -> io::Result<()> {
+        mio::unix::EventedFd(&self.as_raw_fd()).register(poll, token, interest, opts)
+    }
+
+    fn reregister(&self, poll: &mio::Poll, token: mio::Token,
+                  interest: mio::Ready, opts: mio::PollOpt) -> io::Result<()> {
+        mio::unix::EventedFd(&self.as_raw_fd()).reregister(poll, token, interest, opts)
+    }
+
+    fn deregister(&self, poll: &mio::Poll) -> io::Result<()> {
+        mio::unix::EventedFd(&self.as_raw_fd()).deregister(poll)
+    }
+}
 
 pub struct XcbEventStream {
-    conn: Connection,
+    io: PollEvented<InnerStream>,
 }
 
 impl XcbEventStream {
-    pub fn new(conn: Connection) -> XcbEventStream {
-        XcbEventStream { conn }
+    pub fn new(conn: Connection, handle: &Handle) -> Result<XcbEventStream> {
+        Ok(XcbEventStream {
+            io: PollEvented::new(InnerStream(conn), handle)?,
+        })
     }
+
 }
 
 impl Stream for XcbEventStream {
@@ -17,9 +50,16 @@ impl Stream for XcbEventStream {
     type Error = Error;
 
     fn poll(&mut self) -> Poll<Option<GenericEvent>, Error> {
-        match self.conn.poll_for_event() {
+        if Async::NotReady == self.io.poll_read() {
+            return Ok(Async::NotReady);
+        }
+
+        match self.io.get_ref().0.poll_for_event() {
             Some(event) => Ok(Async::Ready(Some(event))),
-            None => Ok(Async::NotReady),
+            None => {
+                self.io.need_read();
+                Ok(Async::NotReady)
+            },
         }
     }
 }


### PR DESCRIPTION
This implementation registers the XCB connection socket properly to
mio, which should prevent any hangs and blocks.