### PR TITLE
Fix panic in WindowTitle component

### DIFF
--- a/src/components/window_title.rs
+++ b/src/components/window_title.rs
@@ -97,7 +97,9 @@ impl Component for WindowTitle {
                 let property_atom = property_event.atom();
                 property_atom == active_window
             })
-            .and_then(move |_| self.get_window_title());
+            .and_then(move |_| {
+                self.get_window_title().or_else(|_| Ok(String::new()))
+            });
 
         Box::new(stream)
     }


### PR DESCRIPTION
I have no idea how I missed it. But I just wanted to play around with this, right after the original PR was merged and noticed this failure.

When the active window is the root window, the WindowTitle component
failed with an error. Now the `get_window_title` method always falls
back to `String::new()` to prevent this from happening.