### PR TITLE
Fix window properties

### DIFF
--- a/src/bar_builder.rs
+++ b/src/bar_builder.rs
@@ -199,7 +199,7 @@ impl<'a> BarBuilder<'a> {
                 &screen,
                 &geometry,
                 self.bg_color.as_u32(),
-                &self.window_title,
+                &self.window_title.as_bytes(),
             )?;
             visualtype = find_visualtype(&screen).unwrap();
 
@@ -426,26 +426,32 @@ fn get_primary_screen_info<'s>(
     )?)
 }
 
-/// Convinience macro for setting EWMH properites.
-macro_rules! set_ewmh_prop {
+/// Convinience macro for setting window properites.
+macro_rules! set_prop {
     ($conn:expr, $window:expr, $name:expr, @atom $value:expr) => {
         {
-            let value_atom = xcb::intern_atom($conn, true, $value)
+            let atom_atom = xcb::intern_atom($conn, true, $value)
                 .get_reply().unwrap().atom();
-            set_ewmh_prop!($conn, $window, $name, &[value_atom]);
+            set_prop!($conn, $window, $name, &[atom_atom], "ATOM", 32);
         }
     };
     ($conn:expr, $window:expr, $name:expr, $data:expr) => {
         {
-            let type_atom = xcb::intern_atom($conn, true, $name)
+            set_prop!($conn, $window, $name, $data, "CARDINAL", 32);
+        }
+    };
+    ($conn:expr, $window:expr, $name:expr, $data:expr, $type:expr, $size:expr) => {
+        {
+            let type_atom = xcb::intern_atom($conn, true, $type).get_reply().unwrap().atom();
+            let property = xcb::intern_atom($conn, true, $name)
                 .get_reply().unwrap().atom();
             xcb::change_property(
                 $conn,
                 xcb::PROP_MODE_REPLACE as u8,
                 $window,
+                property,
                 type_atom,
-                xcb::ATOM_ATOM,
-                32,
+                $size,
                 $data);
         }
     };
@@ -457,7 +463,7 @@ fn create_window<'s>(
     screen: &Screen<'s>,
     geometry: &Rectangle,
     background: u32,
-    window_title: &str,
+    window_title: &[u8],
 ) -> Result<Window> {
     let window = conn.generate_id();
 
@@ -490,20 +496,13 @@ fn create_window<'s>(
     strut[8] = 5;
     strut[9] = 1915;
 
-    set_ewmh_prop!(conn, window, "_NET_WM_WINDOW_TYPE", @atom "_NET_WM_WINDOW_TYPE_DOCK");
-    set_ewmh_prop!(conn, window, "_NET_WM_STATE", @atom "_NET_WM_STATE_STICKY");
-    set_ewmh_prop!(conn, window, "_NET_WM_DESKTOP", &[-1]);
-    set_ewmh_prop!(conn, window, "_NET_WM_STRUT_PARTIAL", strut.as_slice());
-    set_ewmh_prop!(conn, window, "_NET_WM_STRUT", &strut[0..4]);
-    xcb::change_property(
-        conn,
-        xcb::PROP_MODE_REPLACE as u8,
-        window,
-        xcb::ATOM_WM_NAME,
-        xcb::ATOM_STRING,
-        8,
-        window_title.as_bytes(),
-    );
+    set_prop!(conn, window, "_NET_WM_WINDOW_TYPE", @atom "_NET_WM_WINDOW_TYPE_DOCK");
+    set_prop!(conn, window, "_NET_WM_STATE", @atom "_NET_WM_STATE_STICKY");
+    set_prop!(conn, window, "_NET_WM_DESKTOP", &[-1]);
+    set_prop!(conn, window, "_NET_WM_STRUT_PARTIAL", strut.as_slice());
+    set_prop!(conn, window, "_NET_WM_STRUT", &strut[0..4]);
+    set_prop!(conn, window, "_NET_WM_NAME", window_title, "UTF8_STRING", 8);
+    set_prop!(conn, window, "WM_NAME", window_title, "STRING", 8);
 
     // Request the WM to manage our window.
     xcb::map_window(conn, window);

--- a/src/bar_builder.rs
+++ b/src/bar_builder.rs
@@ -199,7 +199,7 @@ impl<'a> BarBuilder<'a> {
                 &screen,
                 &geometry,
                 self.bg_color.as_u32(),
-                &self.window_title.as_bytes(),
+                self.window_title.as_bytes(),
             )?;
             visualtype = find_visualtype(&screen).unwrap();
 
@@ -212,7 +212,7 @@ impl<'a> BarBuilder<'a> {
                 screen.root(),
                 &[
                     (xcb::GC_FOREGROUND, self.bg_color.as_u32()),
-                    (xcb::GC_GRAPHICS_EXPOSURES, 0),
+                    (xcb::GC_GRAPHICS_EXPOSURES, 0)
                 ]
             );
         }
@@ -361,9 +361,9 @@ fn get_screen_info<'s>(
     // Load screen resources of the root window
     // Return result on error
     let res_cookie = randr::get_screen_resources(conn, screen.root());
-    let res_reply = res_cookie.get_reply().map_err(
-        |_| "Unable to get screen resources",
-    )?;
+    let res_reply = res_cookie
+        .get_reply()
+        .map_err(|_| "Unable to get screen resources")?;
 
     // Get all crtcs from the reply
     let crtcs = res_reply.crtcs();
@@ -407,23 +407,23 @@ fn get_primary_screen_info<'s>(
 ) -> Result<xcb::Reply<xcb::ffi::randr::xcb_randr_get_crtc_info_reply_t>> {
     // Load primary output
     let output_cookie = randr::get_output_primary(conn, screen.root());
-    let output_reply = output_cookie.get_reply().map_err(
-        |_| "Unable to get primary output.",
-    )?;
+    let output_reply = output_cookie
+        .get_reply()
+        .map_err(|_| "Unable to get primary output.")?;
     let output = output_reply.output();
 
     // Get crtc of primary output
     let output_info_cookie = randr::get_output_info(conn, output, 0);
-    let output_info_reply = output_info_cookie.get_reply().map_err(
-        |_| "Unable to get info about primary output",
-    )?;
+    let output_info_reply = output_info_cookie
+        .get_reply()
+        .map_err(|_| "Unable to get info about primary output")?;
     let crtc = output_info_reply.crtc();
 
     // Get info of primary output's crtc
     let crtc_info_cookie = randr::get_crtc_info(conn, crtc, 0);
-    Ok(crtc_info_cookie.get_reply().map_err(
-        |_| "Unable to get crtc from primary output",
-    )?)
+    Ok(crtc_info_cookie
+        .get_reply()
+        .map_err(|_| "Unable to get crtc from primary output")?)
 }
 
 /// Convinience macro for setting window properites.


### PR DESCRIPTION
Due to incorrect type atoms the window properties have been set
incorrectly. To fix this the `set_ewmh_prop!` macro has been reworked.
It now is a lot more flexible, which also lead to the `set_prop!`
rename. This fixes #37.

Because this now allows easier change of properties I've also set the
window title property using both `_NET_WM_NAME` and `WM_NAME` so this
should also fix #33.