### PR TITLE
Add basic Time component

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,4 @@ tokio-io = "*"
 tokio-process = "*"
 tokio-timer = "*"
 xcb = { git = "https://github.com/rtbo/rust-xcb.git", features = ["randr"] }
+time = "0.1.38"

--- a/src/components/clock.rs
+++ b/src/components/clock.rs
@@ -1,15 +1,14 @@
 use std::time::{Duration, Instant};
 use tokio_core::reactor::Handle;
+use error::{Error, Result};
 use component::Component;
 use tokio_timer::Timer;
 use futures::Stream;
-use error::Error;
 use time;
 
 /// A `Clock` that automatically determines the refresh rate.
 ///
-/// This uses the default [strftime](https://linux.die.net/man/3/strftime) syntax for formatting.
-/// Escaping `%` using `%%` is however not supported.
+/// This uses the default [strftime](http://man7.org/linux/man-pages/man3/strftime.3.html) syntax for formatting.
 pub struct Clock {
     format: String,
     refresh_rate: Duration,
@@ -30,25 +29,39 @@ impl Default for Clock {
 
 impl Clock {
     /// Create a new `Clock` specifying the time format as argument.
-    pub fn new<T: Into<String>>(format: T) -> Clock {
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if the specified `strftime` format could not be parsed.
+    pub fn new<T: Into<String>>(format: T) -> Result<Clock> {
         let format = format.into();
-        let refresh_rate = get_refresh_rate(&format);
-        Clock {
+        let refresh_rate = get_refresh_rate(&format)?;
+        Ok(Clock {
             format: format,
             refresh_rate,
-        }
+        })
     }
 }
 
 // Checks if seconds are part of the `strftime` format.
 // If there are no seconds the refresh rate is one minute, otherwise it's one second.
-fn get_refresh_rate(format: &str) -> Duration {
-    for i in &["%c", "%r", "%S", "%T", "%X"] {
-        if format.contains(i) {
-            return Duration::from_secs(1);
-        }
+fn get_refresh_rate(format: &str) -> Result<Duration> {
+    // Create a time with any non-zero second value
+    let mut time = time::now();
+    time.tm_sec = 15;
+
+    // Convert to String and back to Tm
+    let time_str = time::strftime(format, &time)
+        .map_err(|_| "Invalid clock format.")?;
+    let time = time::strptime(&time_str, format)
+        .map_err(|_| "Invalid clock format.")?;
+
+    // Check if seconds are still there
+    if time.tm_sec != 0 {
+        Ok(Duration::from_secs(1))
+    } else {
+        Ok(Duration::from_secs(60))
     }
-    Duration::from_secs(60)
 }
 
 impl Component for Clock {

--- a/src/components/clock.rs
+++ b/src/components/clock.rs
@@ -8,7 +8,8 @@ use time;
 
 /// A `Clock` that automatically determines the refresh rate.
 ///
-/// This uses the default [strftime](http://man7.org/linux/man-pages/man3/strftime.3.html) syntax for formatting.
+/// This uses the default [strftime](http://man7.org/linux/man-pages/man3/strftime.3.html)
+/// syntax for formatting.
 pub struct Clock {
     format: String,
     refresh_rate: Duration,
@@ -18,7 +19,7 @@ impl Default for Clock {
     /// Creates a `Clock` without any arguments.
     ///
     /// This uses `%T` as the default time format.
-    /// [Read more](https://doc.rust-lang.org/nightly/core/default/trait.Default.html#tymethod.default)
+    /// [Read more](https://doc.rust-lang.org/core/default/trait.Default.html#tymethod.default)
     fn default() -> Clock {
         Clock {
             format: "%T".into(),

--- a/src/components/clock.rs
+++ b/src/components/clock.rs
@@ -1,0 +1,66 @@
+use std::time::{Duration, Instant};
+use tokio_core::reactor::Handle;
+use component::Component;
+use tokio_timer::Timer;
+use futures::Stream;
+use error::Error;
+use time;
+
+/// A `Clock` that automatically determines the refresh rate.
+///
+/// This uses the default [strftime](https://linux.die.net/man/3/strftime) syntax for formatting.
+/// Escaping `%` using `%%` is however not supported.
+pub struct Clock {
+    format: String,
+    refresh_rate: Duration,
+}
+
+impl Default for Clock {
+    /// Creates a `Clock` without any arguments.
+    ///
+    /// This uses `%T` as the default time format.
+    /// [Read more](https://doc.rust-lang.org/nightly/core/default/trait.Default.html#tymethod.default)
+    fn default() -> Clock {
+        Clock {
+            format: "%T".into(),
+            refresh_rate: Duration::from_secs(1),
+        }
+    }
+}
+
+impl Clock {
+    /// Create a new `Clock` specifying the time format as argument.
+    pub fn new<T: Into<String>>(format: T) -> Clock {
+        let format = format.into();
+        let refresh_rate = get_refresh_rate(&format);
+        Clock {
+            format: format,
+            refresh_rate,
+        }
+    }
+}
+
+// Checks if seconds are part of the `strftime` format.
+// If there are no seconds the refresh rate is one minute, otherwise it's one second.
+fn get_refresh_rate(format: &str) -> Duration {
+    for i in &["%c", "%r", "%S", "%T", "%X"] {
+        if format.contains(i) {
+            return Duration::from_secs(1);
+        }
+    }
+    Duration::from_secs(60)
+}
+
+impl Component for Clock {
+    type Error = Error;
+    type Stream = Box<Stream<Item = String, Error = Error>>;
+
+    fn stream(self, _: Handle) -> Self::Stream {
+        let timer = Timer::default();
+
+        let format = self.format.clone();
+        timer.interval_at(Instant::now(), self.refresh_rate).and_then(move |()| {
+            Ok(time::strftime(&format, &time::now()).unwrap())
+        }).map_err(|_| "timer error".into()).boxed()
+    }
+}

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -2,8 +2,10 @@ pub mod pipe;
 pub mod network_usage;
 pub mod text;
 pub mod window_title;
+pub mod clock;
 
 pub use self::pipe::Pipe;
 pub use self::network_usage::NetworkUsage;
 pub use self::text::Text;
 pub use self::window_title::WindowTitle;
+pub use self::clock::Clock;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ extern crate error_chain;
 extern crate pangocairo;
 extern crate procinfo;
 extern crate tokio_timer;
+extern crate time;
 
 #[macro_use]
 mod utils;


### PR DESCRIPTION
Added a basic time component that doesn't rely on the `date` command.
This is an initial prototype for the smart clock described in
dogamak/xcbars#3. It chooses the refresh rate of one minute/one second
depending on the time format.

If you have any feedback on what kind of direction you would like this to go, feel free to tell me and I'll try to add it to this PR. That said the component is already working and usable.