### PR TITLE
Improve Travis CI integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,4 @@ tokio-io = "*"
 tokio-process = "*"
 tokio-timer = "*"
 xcb = { git = "https://github.com/rtbo/rust-xcb.git", features = ["randr"] }
+time = "0.1.38"

--- a/src/components/clock.rs
+++ b/src/components/clock.rs
@@ -1,0 +1,66 @@
+use std::time::{Duration, Instant};
+use tokio_core::reactor::Handle;
+use component::Component;
+use tokio_timer::Timer;
+use futures::Stream;
+use error::Error;
+use time;
+
+/// A `Clock` that automatically determines the refresh rate.
+///
+/// This uses the default [strftime](https://linux.die.net/man/3/strftime) syntax for formatting.
+/// Escaping `%` using `%%` is however not supported.
+pub struct Clock {
+    format: String,
+    refresh_rate: Duration,
+}
+
+impl Default for Clock {
+    /// Creates a `Clock` without any arguments.
+    ///
+    /// This uses `%T` as the default time format.
+    /// [Read more](https://doc.rust-lang.org/nightly/core/default/trait.Default.html#tymethod.default)
+    fn default() -> Clock {
+        Clock {
+            format: "%T".into(),
+            refresh_rate: Duration::from_secs(1),
+        }
+    }
+}
+
+impl Clock {
+    /// Create a new `Clock` specifying the time format as argument.
+    pub fn new<T: Into<String>>(format: T) -> Clock {
+        let format = format.into();
+        let refresh_rate = get_refresh_rate(&format);
+        Clock {
+            format: format,
+            refresh_rate,
+        }
+    }
+}
+
+// Checks if seconds are part of the `strftime` format.
+// If there are no seconds the refresh rate is one minute, otherwise it's one second.
+fn get_refresh_rate(format: &str) -> Duration {
+    for i in &["%c", "%r", "%S", "%T", "%X"] {
+        if format.contains(i) {
+            return Duration::from_secs(1);
+        }
+    }
+    Duration::from_secs(60)
+}
+
+impl Component for Clock {
+    type Error = Error;
+    type Stream = Box<Stream<Item = String, Error = Error>>;
+
+    fn stream(self, _: Handle) -> Self::Stream {
+        let timer = Timer::default();
+
+        let format = self.format.clone();
+        timer.interval_at(Instant::now(), self.refresh_rate).and_then(move |()| {
+            Ok(time::strftime(&format, &time::now()).unwrap())
+        }).map_err(|_| "timer error".into()).boxed()
+    }
+}

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -2,8 +2,10 @@ pub mod pipe;
 pub mod network_usage;
 pub mod text;
 pub mod window_title;
+pub mod clock;
 
 pub use self::pipe::Pipe;
 pub use self::network_usage::NetworkUsage;
 pub use self::text::Text;
 pub use self::window_title::WindowTitle;
+pub use self::clock::Clock;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ extern crate error_chain;
 extern crate pangocairo;
 extern crate procinfo;
 extern crate tokio_timer;
+extern crate time;
 
 #[macro_use]
 mod utils;


### PR DESCRIPTION
When working with the past few commits I've noticed that new clippy and rustfmt issues got introduced. This kinda bothered me and I thought Travis CI should prevent this from happening by checking the stable build, clippy on nightly and rustfmt on nightly.

This uses two docker images (`undeadleech/xcbars-nightly` and `undeadleech/xcbars-stable`) and pulls them from the docker registry. Then it runs the builds on the image specified in the `.travis.yml`.

This not only has the advantage of checking clippy and rustfmt with every commit, but it also improves build times significantly. It does not build an image from scratch but pulls a pre-built image which will not need to pull any libs from the debian mirrors. This also solves the issue of the CI failing because of issues with the Debian mirrors.

I am not sure what your stance on Clippy/Fmt in CI is, but I think the improvement on compile time should definitely be introduced to master. And I think Clippy/Fmt would also be a great addition to the CI cycle (with tests hopefully coming in the near future).

This PR will fail 2/3 tests because both Clippy and RustFmt are currently throwing errors. The main `cargo build` should still succeed tho. 

I recommend merging this before #34 to test that it actually works.