### PR TITLE
Add buffer to network_usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ description = "A standalone bar library created with XCB, cairo and pango."
 repository = "https://github.com/dogamak/xcbars"
 documentation = "docs.rs/xcbars"
 license = "Apache-2.0"
-license-file = "LICENSE"
 readme = "README.md"
 
 [badges.tarvis-ci]


### PR DESCRIPTION
Added a basic buffer to the network_usage. This just smoothes out the
traffic data by a bit. The default buffer is configured with the size 5
and works pretty well.

Also removed the `license-file` from the `Cargo.toml`. I made this
change in the RustFmt and Clippy fix PR already but it seems like I
accidentally reverted it. This just removes a compiler warning.

In theory this should fix #15 assuming I've understood the result you're trying to achieve correctly.